### PR TITLE
Fix faulty YAML in swagger.yaml

### DIFF
--- a/pkg/swagger/swagger.yaml
+++ b/pkg/swagger/swagger.yaml
@@ -47,7 +47,6 @@ paths:
           description: failure
           schema:
             $ref: '#/definitions/responseBody500'
-          description: failure
 
   /metrics:
     get:


### PR DESCRIPTION
swagger.yaml gets rejected by OpenAPI code generators because of a duplicated YAML field.